### PR TITLE
changes how .Values.config are written to secret through extra templa…

### DIFF
--- a/charts/gatekeeper/templates/config.yaml
+++ b/charts/gatekeeper/templates/config.yaml
@@ -7,4 +7,4 @@ metadata:
 type: Opaque
 stringData:
   config.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- tpl (.Values.config | toYaml) $ | nindent 4 }}

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -220,6 +220,7 @@ config:
   #   roles:
   #   - openvpn:vpn-user
   #   - openvpn:prod-vpn
+  #   - "{{ .Values.adminTestRole }}
   #   - test
   # - uri: /admin/*
   #   methods:


### PR DESCRIPTION
We need to be able to template roles into the config key in `values.yaml` per stage, to be more specific 
under 

```
config:
  resources:
    - uri: /admin/test
       roles:  
       - "{{ .Values.adminTestRole }}"
```
 
For that, I extended template capabilities of config.yaml.
It is now possible to define a arbitrary key in values.yaml let's say  `.Values.adminTestRole` which then can be used like above.
